### PR TITLE
Create storage acct as part of one-click Azure deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 
 ## Components of the Guardian Connector Stack
 
+### 🖥️ Compute
+
+A computer server to run the software.
+
+- a virtual machine in the cloud of your choice.
+
 ### 📂 Storage for your Data Warehouse
 
 Store, organize, and selectively share all your data. The warehouse consists of:
 
 - a filesystem for media (pictures, maps, videos)
 - a SQL Database for tabular data & surveys
-
-### 🖥️ Compute
-
-A computer server to run the software.
-
-- a virtual machine in the cloud of your choice.
 
 ### 📦 App stack
 
@@ -28,15 +28,16 @@ Deploy software easily with [CapRover](https://caprover.com/).
 
 ## High-level steps to spawn a new stack
 
-1. Create your data warehouse: file storage & a SQL database.
-    - NOTE: If you are deploying your SQL database or storing files on the VM directly, you do not need to do this step first.
-    - A private repo [`gc-forge`](https://github.com/ConservationMetrics/gc-forge/blob/main/terraform/README.md) helps set this up on Azure, but but you do not need to use terraform or Azure.
-2. If you plan on using auth0, set up an **auth0 tenant** with a user authorization workflow and client applications to help secure access to the apps you will deploy. See [`auth0/README.md`](auth0/README.md)
-3. Deploy a VM.
+1. Deploy a VM.
     - [`azure/README.md`](azure/README.md) describes setting this up on Azure.
     - [`digitalocean-vm/README.md`](digitalocean-vm/README.md) describes setting up a VM with CapRover included on DigitalOcean.
     - With the right amount of knowledge, you can follow the above guides and/or CapRover's own [Getting Started](https://caprover.com/docs/get-started.html) guide to figure out how to deploy a VM on your hosting platform of choice.
-4. Install the app stack by following [`caprover/README.md`](https://github.com/ConservationMetrics/gc-forge/blob/main/caprover/README.md).
-5. Set up data pipelines & other scripts to run in Windmill.
+
+2. Create your data warehouse: file storage & a SQL database.
+    - The Azure deployment can automatically create an Azure Storage Account and Files share for you, or you can use an existing one. If you are storing files on the VM directly, you can skip Azure Files entirely.
+2. If you plan on using auth0, set up an **auth0 tenant** with a user authorization workflow and client applications to help secure access to the apps you will deploy. See [`auth0/README.md`](auth0/README.md)
+
+3. Install the app stack by following [`caprover/README.md`](https://github.com/ConservationMetrics/gc-forge/blob/main/caprover/README.md).
+4. Set up data pipelines & other scripts to run in Windmill.
     - See [**ConservationMetrics/gc-scripts-hub**](https://github.com/ConservationMetrics/gc-scripts-hub/)
 

--- a/azure/README.md
+++ b/azure/README.md
@@ -1,8 +1,17 @@
 # Launch a VM in Azure
 
-## One-click Quick Deployment
+## 🚀 Quick Deployment (5 minutes)
 
-[Deploy a new VM on Azure](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FConservationMetrics%2Fgc-stack-deploy%2Frefs%2Fheads%2Fmain%2Fbuild%2Fazure%2Fnew-vm.arm.json)
+1. [Click here to deploy a new VM on Azure](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.2. com%2FConservationMetrics%2Fgc-stack-deploy%2Frefs%2Fheads%2Fmain%2Fbuild%2Fazure%2Fnew-vm.arm.json)
+2. Fill in required fields:
+   - Resource Group: Create new (e.g. `guardian-«community»`)
+   - Storage account:
+      - `createStorageAccount: true` to create a new storage account
+      - `createStorageAccount: false` and give a `Storage Account Name` & `Folder` to use an existing Azure storage account.
+      - `createStorageAccount: false` and skip `Storage Account Name` & `Folder` to store files directly on the VM.
+   - Admin Password: Strong password for VM login
+3. Click "Review + Create"
+4. After deployment: SSH to your VM and install CapRover
 
 ## Prerequisites
 

--- a/azure/README.md
+++ b/azure/README.md
@@ -4,6 +4,10 @@
 
 [Deploy a new VM on Azure](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FConservationMetrics%2Fgc-stack-deploy%2Frefs%2Fheads%2Fmain%2Fbuild%2Fazure%2Fnew-vm.arm.json)
 
+## Prerequisites
+
+Your Azure user must have **Contributor** role on an existing Resource Group to deploy the stack,
+or **Contributor** role on the Subscription to create a new Resource Group for the stack.
 
 ## Instructions
 

--- a/azure/README.md
+++ b/azure/README.md
@@ -29,6 +29,7 @@ Many communities keep their data lake files on Azure Files. This is optional.
 
 2. **To not use Azure Files:**
    - Delete the entire `write_files:` section from `cloud-config.yml`
+   - When deploying, set `createStorageAccount` to `false`
 
 NOTEs:
 - The `cloud-config.yml` contains ARM template parameter references like `parameters('storageAccountName')` which are invalid YAML but get processed correctly by the ARM template at deployment time. The build script converts the cloud-init configuration into a properly escaped JSON string for embedding in the ARM template

--- a/azure/build.sh
+++ b/azure/build.sh
@@ -12,7 +12,7 @@ awk 'NR > 1 {printf(", ")} {gsub(/"/, "\\\""); printf "\047%s\\n\047", $0}' < cl
 
 # Wrap the entire content of replacement.txt with a JSON property definition
 # that wraps the cloud-init content in ARM template base64(concat()) function
-gawk -i inplace '$0="\"cloudInit\": \"[base64(concat("$0"))]\""' replacement.txt
+gawk -i inplace '$0="          \"customData\": \"[base64(concat("$0"))]\","' replacement.txt
 
 # Find the __CLOUD_INIT__ placeholder in new-vm.arm.json.
 # Replace its entire line with the contents of replacement.txt (r command),

--- a/azure/cloud-config.yml
+++ b/azure/cloud-config.yml
@@ -31,4 +31,4 @@ write_files:
       #!/bin/bash
       MOUNT_PATH=/mnt/persistent-storage
       mkdir -p "$MOUNT_PATH"
-      mount -t cifs //', parameters('storageAccountName'), '.file.core.windows.net/', parameters('storageAccountFolder'), ' "$MOUNT_PATH" -o "vers=3.0,username=', parameters('storageAccountName'), ',password=', parameters('storageAccessKey'), ',dir_mode=0777,file_mode=0777,serverino" || true
+      mount -t cifs //', parameters('storageAccountName'), '.file.core.windows.net/', parameters('storageAccountFolder'), ' "$MOUNT_PATH" -o "vers=3.0,username=', parameters('storageAccountName'), ',password=', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2022-09-01').keys[0].value, ',dir_mode=0777,file_mode=0777,serverino" || true

--- a/azure/new-vm.arm.json
+++ b/azure/new-vm.arm.json
@@ -2,6 +2,28 @@
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "createStorageAccount": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Whether to create a new storage account or use existing one"
+      }
+    },
+    "storageAccountName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Name of the storage account (existing or to be created). Leave empty to skip Azure Files mounting."
+      }
+    },
+    "storageAccountFolder": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Name of the Files share in the Storage Account. Leave empty to skip Azure Files mounting."
+      }
+    },
+
     "vmName": {
       "type": "String",
       "defaultValue": "guardian-XXXX",
@@ -29,27 +51,32 @@
       "metadata": {
         "description": "Password to login to the Virtual Machine."
       }
-    },
-    "storageAccountName": {
-      "type": "string",
-      "metadata": {
-        "description": "Name of the Azure Storage Account to mount"
-      }
-    },
-    "storageAccountFolder": {
-      "type": "string",
-      "metadata": {
-        "description": "Name of the Files share in the Storage Account"
-      }
-    },
-    "storageAccessKey": {
-      "type": "securestring",
-      "metadata": {
-        "description": "Access key for the storage account"
-      }
     }
   },
   "resources": [
+    {
+      "condition": "[parameters('createStorageAccount')]",
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2023-01-01",
+      "name": "[parameters('storageAccountName')]",
+      "location": "[resourceGroup().location]",
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "kind": "StorageV2",
+      "properties": {
+        "accessTier": "Hot"
+      }
+    },
+    {
+      "condition": "[parameters('createStorageAccount')]",
+      "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+      "apiVersion": "2023-01-01",
+      "name": "[concat(parameters('storageAccountName'), '/default/', parameters('storageAccountFolder'))]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+      ]
+    },
     {
       "type": "Microsoft.Network/publicIPAddresses",
       "apiVersion": "2024-01-01",
@@ -171,7 +198,7 @@
           "vmSize": "[parameters('vmSize')]"
         },
         "osProfile": {
-          "customData": "[variables('cloudInit')]",
+          "customData": "__CLOUD_INIT__",
           "allowExtensionOperations": true,
           "computerName": "[parameters('vmName')]",
           "adminUsername": "[parameters('adminUsername')]",
@@ -361,8 +388,6 @@
     "nicName": "[concat(parameters('vmName'), '-nic') ]",
     "networkSecurityGroupName": "[concat(parameters('vmName'), '-nsg') ]",
     "publicIpName": "[concat(parameters('vmName'), '-ip') ]",
-    "virtualNetworkName": "[concat(parameters('vmName'), '-vnet') ]",
-
-    "cloudInit": "__CLOUD_INIT__"
+    "virtualNetworkName": "[concat(parameters('vmName'), '-vnet') ]"
   }
 }

--- a/azure/new-vm.arm.json
+++ b/azure/new-vm.arm.json
@@ -49,7 +49,7 @@
       "type": "securestring",
       "minLength": 16,
       "metadata": {
-        "description": "Password to login to the Virtual Machine."
+        "description": "Password to login to the Virtual Machine. Must be 16+ characters"
       }
     }
   },

--- a/build/azure/new-vm.arm.json
+++ b/build/azure/new-vm.arm.json
@@ -2,6 +2,28 @@
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "createStorageAccount": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Whether to create a new storage account or use existing one"
+      }
+    },
+    "storageAccountName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Name of the storage account (existing or to be created). Leave empty to skip Azure Files mounting."
+      }
+    },
+    "storageAccountFolder": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Name of the Files share in the Storage Account. Leave empty to skip Azure Files mounting."
+      }
+    },
+
     "vmName": {
       "type": "String",
       "defaultValue": "guardian-XXXX",
@@ -29,27 +51,32 @@
       "metadata": {
         "description": "Password to login to the Virtual Machine."
       }
-    },
-    "storageAccountName": {
-      "type": "string",
-      "metadata": {
-        "description": "Name of the Azure Storage Account to mount"
-      }
-    },
-    "storageAccountFolder": {
-      "type": "string",
-      "metadata": {
-        "description": "Name of the Files share in the Storage Account"
-      }
-    },
-    "storageAccessKey": {
-      "type": "securestring",
-      "metadata": {
-        "description": "Access key for the storage account"
-      }
     }
   },
   "resources": [
+    {
+      "condition": "[parameters('createStorageAccount')]",
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2023-01-01",
+      "name": "[parameters('storageAccountName')]",
+      "location": "[resourceGroup().location]",
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "kind": "StorageV2",
+      "properties": {
+        "accessTier": "Hot"
+      }
+    },
+    {
+      "condition": "[parameters('createStorageAccount')]",
+      "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+      "apiVersion": "2023-01-01",
+      "name": "[concat(parameters('storageAccountName'), '/default/', parameters('storageAccountFolder'))]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+      ]
+    },
     {
       "type": "Microsoft.Network/publicIPAddresses",
       "apiVersion": "2024-01-01",
@@ -171,7 +198,7 @@
           "vmSize": "[parameters('vmSize')]"
         },
         "osProfile": {
-          "customData": "[variables('cloudInit')]",
+          "customData": "[base64(concat('#cloud-config\n', 'package_update: true\n', '\n', 'apt:\n', '  sources:\n', '    # from: https://stackoverflow.com/a/62706447\n', '    docker.list:\n', '      source: deb [arch=amd64] https://download.docker.com/linux/ubuntu $RELEASE stable\n', '      keyid: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88\n', '\n', 'packages:\n', '  # Docker\n', '  - docker-ce\n', '  - docker-ce-cli\n', '\n', '  # For SMB mount to Azure Files\n', '  - cifs-utils\n', '  - smbclient\n', '\n', 'runcmd:\n', '  - mkdir -p /var/lib/cloud/scripts/per-boot\n', '  - mkdir -p /etc/systemd/journald.conf.d/\n', '\n', 'write_files:\n', '  - path: /var/lib/cloud/scripts/per-boot/mount-datalake.sh\n', '    # Have the datalake network storage mounted locally at each boot.\n', '    # This `mount-datalake.sh` script is run at each boot (including\n', '    # the very first one, i.e. after instance creation).\n', '    permissions: \"0755\"\n', '    content: |\n', '      #!/bin/bash\n', '      MOUNT_PATH=/mnt/persistent-storage\n', '      mkdir -p \"$MOUNT_PATH\"\n', '      mount -t cifs //', parameters('storageAccountName'), '.file.core.windows.net/', parameters('storageAccountFolder'), ' \"$MOUNT_PATH\" -o \"vers=3.0,username=', parameters('storageAccountName'), ',password=', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2022-09-01').keys[0].value, ',dir_mode=0777,file_mode=0777,serverino\" || true\n'))]",
           "allowExtensionOperations": true,
           "computerName": "[parameters('vmName')]",
           "adminUsername": "[parameters('adminUsername')]",
@@ -361,8 +388,6 @@
     "nicName": "[concat(parameters('vmName'), '-nic') ]",
     "networkSecurityGroupName": "[concat(parameters('vmName'), '-nsg') ]",
     "publicIpName": "[concat(parameters('vmName'), '-ip') ]",
-    "virtualNetworkName": "[concat(parameters('vmName'), '-vnet') ]",
-
-"cloudInit": "[base64(concat('#cloud-config\n', 'package_update: true\n', '\n', 'apt:\n', '  sources:\n', '    # from: https://stackoverflow.com/a/62706447\n', '    docker.list:\n', '      source: deb [arch=amd64] https://download.docker.com/linux/ubuntu $RELEASE stable\n', '      keyid: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88\n', '\n', 'packages:\n', '  # Docker\n', '  - docker-ce\n', '  - docker-ce-cli\n', '\n', '  # For SMB mount to Azure Files\n', '  - cifs-utils\n', '  - smbclient\n', '\n', 'runcmd:\n', '  - mkdir -p /var/lib/cloud/scripts/per-boot\n', '  - mkdir -p /etc/systemd/journald.conf.d/\n', '\n', 'write_files:\n', '  - path: /var/lib/cloud/scripts/per-boot/mount-datalake.sh\n', '    # Have the datalake network storage mounted locally at each boot.\n', '    # This `mount-datalake.sh` script is run at each boot (including\n', '    # the very first one, i.e. after instance creation).\n', '    permissions: \"0755\"\n', '    content: |\n', '      #!/bin/bash\n', '      MOUNT_PATH=/mnt/persistent-storage\n', '      mkdir -p \"$MOUNT_PATH\"\n', '      mount -t cifs //', parameters('storageAccountName'), '.file.core.windows.net/', parameters('storageAccountFolder'), ' \"$MOUNT_PATH\" -o \"vers=3.0,username=', parameters('storageAccountName'), ',password=', parameters('storageAccessKey'), ',dir_mode=0777,file_mode=0777,serverino\" || true\n'))]"
+    "virtualNetworkName": "[concat(parameters('vmName'), '-vnet') ]"
   }
 }

--- a/build/azure/new-vm.arm.json
+++ b/build/azure/new-vm.arm.json
@@ -49,7 +49,7 @@
       "type": "securestring",
       "minLength": 16,
       "metadata": {
-        "description": "Password to login to the Virtual Machine."
+        "description": "Password to login to the Virtual Machine. Must be 16+ characters"
       }
     }
   },


### PR DESCRIPTION
Creating the storage account is optional. Reasons you may not:
- it already exists
- you want to use on-disk storage

![Screenshot from 2025-06-16 16-37-36](https://github.com/user-attachments/assets/fcdd91c6-ae36-487a-9cdc-0b08d0665af5)
